### PR TITLE
Use set :public_folder since set :public is deprecated.

### DIFF
--- a/try_roma.rb
+++ b/try_roma.rb
@@ -7,7 +7,7 @@ include TryRomaAPI
 
 configure do
   use Rack::Session::Pool, :expire_after => 3600 # 10min
-  set :public, File.dirname(__FILE__) + '/public'
+  set :public_folder, File.dirname(__FILE__) + '/public'
 end
 
 helpers do


### PR DESCRIPTION
When launching this app with `rackup`, the following warning message appears: 

```
$ bundle exec rackup ./config.ru
:public is no longer used to avoid overloading Module#public, use :public_folder or :public_dir instead
        from /Users/tatsuya.b.sato/Projects/work/ROMA/try-roma/try_roma.rb:10:in `block in <top (required)>'
Thin web server (v1.6.3 codename Protein Powder)
Maximum connections set to 1024
Listening on localhost:9292, CTRL+C to stop
```

This PR provides the change for resolving this warning. 
